### PR TITLE
Refactor query helper into query runner object

### DIFF
--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -1,6 +1,4 @@
 class QueriesController < ApplicationController
-  include QueriesHelper
-
   def index
     @saved_queries = SavedQuery.all
     load_all_database_connections
@@ -13,7 +11,7 @@ class QueriesController < ApplicationController
     load_query
     load_database_connection
     load_all_database_connections
-    run_query(:raw)
+    run_query
   end
 
   def create
@@ -33,10 +31,10 @@ class QueriesController < ApplicationController
     
     respond_to do |format|
       format.html do
-        run_query(:raw)
+        run_query
       end
       format.json do
-        run_query(:raw)
+        run_query
         render json: @result_json
       end
       format.csv do
@@ -82,7 +80,7 @@ class QueriesController < ApplicationController
     @database_connection = DatabaseConnection.find(params[:database_connection_id])
   end
 
-  def run_query(format)
+  def run_query
     result_obj = QueryRunner.run_query(
       format: format,
       query: @query,
@@ -90,10 +88,8 @@ class QueriesController < ApplicationController
     )
 
     @result = result_obj[:result]
-    if format == :raw
-      @result_hash = result_obj[:hash]
-      @result_json = result_obj[:json]
-    end
+    @result_hash = result_obj[:hash]
+    @result_json = result_obj[:json]
     @result
   rescue PG::Error => e
     @error = e

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -83,10 +83,16 @@ class QueriesController < ApplicationController
   end
 
   def run_query(format)
-    @result = query_db(@query, @database_connection, format)
+    result_obj = QueryRunner.run_query(
+      format: format,
+      query: @query,
+      database_connection: @database_connection
+    )
+
+    @result = result_obj[:result]
     if format == :raw
-      @result_hash = @result.collect {|r| r.to_h }
-      @result_json = @result_hash.to_json
+      @result_hash = result_obj[:hash]
+      @result_json = result_obj[:json]
     end
     @result
   rescue PG::Error => e

--- a/app/controllers/queries_controller.rb
+++ b/app/controllers/queries_controller.rb
@@ -11,7 +11,7 @@ class QueriesController < ApplicationController
     load_query
     load_database_connection
     load_all_database_connections
-    run_query(format: :raw)
+    run_query(format: :html)
   end
 
   def create
@@ -30,7 +30,7 @@ class QueriesController < ApplicationController
     
     respond_to do |format|
       format.html do
-        run_query(format: :raw) # uses @result
+        run_query(format: :html)
       end
       format.json do
         run_query(format: :json)
@@ -84,19 +84,21 @@ class QueriesController < ApplicationController
     format = options[:format]
     raise "No format specified" if format.nil?
 
-    result_obj = QueryRunner.run_query(
-      format: format,
+    query_runner = QueryRunner.new(
       query: @query,
       database_connection: @database_connection
     )
 
     case format
-    when :raw
+    when :html
+      result_obj = query_runner.run(:raw)
       @result = result_obj[:raw]
-      @result_json = result_obj[:json] # used for visualization
+      @result_json = result_obj[:json]
     when :csv
+      result_obj = query_runner.run(:csv)
       @result_csv = result_obj[:csv]
     when :json
+      result_obj = query_runner.run(:json)
       @result_json = result_obj[:json]
     end
 

--- a/app/helpers/queries_helper.rb
+++ b/app/helpers/queries_helper.rb
@@ -1,27 +1,2 @@
 module QueriesHelper
-  def query_db(query, database_connection, format)
-    # XXX move this out of rails into a service object of some kind
-    conn = PG.connect(
-      user: database_connection.user,
-      password: database_connection.password,
-      dbname: database_connection.dbname,
-      host: database_connection.host,
-      port: database_connection.port
-    )
-
-    case format
-    when :raw
-      conn.exec(query)
-    when :csv
-      query = query.gsub(/;/,"")
-      data = []
-      conn.copy_data("COPY (#{query}) TO STDOUT WITH (FORMAT CSV, HEADER TRUE, FORCE_QUOTE *, ESCAPE E'\\\\');") do
-        while row = conn.get_copy_data
-          data.push(row)
-        end
-      end
-      data = data.join("\n")
-      data
-    end
-  end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,6 @@ module QueryClips
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
+    config.autoload_paths << Rails.root.join('lib')
   end
 end

--- a/lib/query_runner.rb
+++ b/lib/query_runner.rb
@@ -1,0 +1,43 @@
+class QueryRunner
+  def self.run_query(options = {})
+    format = options[:format]
+    database_connection = options[:database_connection]
+    query = options[:query]
+
+    result = query_db(query, database_connection, format)
+    result_hash = result.collect { |r| r.to_h }
+    return_value = {
+      result: result,
+      hash: result_hash,
+      json: result_hash.to_json
+    }
+    return_value
+  end
+
+  private
+
+  def self.query_db(query, database_connection, format)
+    conn = PG.connect(
+      user: database_connection.user,
+      password: database_connection.password,
+      dbname: database_connection.dbname,
+      host: database_connection.host,
+      port: database_connection.port
+    )
+
+    case format
+    when :raw
+      conn.exec(query)
+    when :csv
+      query = query.gsub(/;/,"")
+      data = []
+      conn.copy_data("COPY (#{query}) TO STDOUT WITH (FORMAT CSV, HEADER TRUE, FORCE_QUOTE *, ESCAPE E'\\\\');") do
+        while row = conn.get_copy_data
+          data.push(row)
+        end
+      end
+      data = data.join("\n")
+      data
+    end
+  end
+end

--- a/lib/query_runner.rb
+++ b/lib/query_runner.rb
@@ -5,12 +5,14 @@ class QueryRunner
     query = options[:query]
 
     result = query_db(query, database_connection, format)
-    result_hash = result.collect { |r| r.to_h }
-    return_value = {
-      result: result,
-      hash: result_hash,
-      json: result_hash.to_json
-    }
+    return_value = {}
+    if format == :csv
+      return_value[:csv] = result
+    else
+      result_hash = result.collect { |r| r.to_h }
+      return_value[:raw] = result
+      return_value[:json] = result_hash.to_json
+    end
     return_value
   end
 
@@ -27,6 +29,8 @@ class QueryRunner
 
     case format
     when :raw
+      conn.exec(query)
+    when :json
       conn.exec(query)
     when :csv
       query = query.gsub(/;/,"")


### PR DESCRIPTION
Closes #10 

`QueriesHelper` has been replaced by a new, vanilla `QueryRunner` class. This makes way for database-agnostic queries, and ensures that the user flows in the app are loosely coupled to the database querying logic.

I considered making the object even more loosely coupled to the `DatabaseConnection` class by having a separate object to translate between the two, but opted instead to simply encompass that logic in the `connection_from_database_connection` method.